### PR TITLE
fix: resolve UTC timezone mismatch on dashboard update age

### DIFF
--- a/compass_dashboard_cloud.py
+++ b/compass_dashboard_cloud.py
@@ -859,6 +859,20 @@ def _health_cycle_counts(state, engine):
     return int(cycles_completed or 0), int(engine_iterations or 0)
 
 
+def _snap_weekend_to_monday(date_str):
+    """If date_str falls on Sat/Sun, return next Monday. Otherwise pass through."""
+    if not date_str or not isinstance(date_str, str):
+        return date_str
+    try:
+        d = date.fromisoformat(date_str[:10])
+        if d.weekday() >= 5:
+            d += timedelta(days=(7 - d.weekday()))
+        return d.isoformat()
+    except (ValueError, TypeError):
+        logger.warning(f"_snap_weekend_to_monday: invalid date_str={date_str!r}")
+        return date_str
+
+
 def _last_cycle_close_timestamp(state):
     if state:
         for key in ('last_cycle_close', 'last_cycle_close_at'):
@@ -1314,7 +1328,7 @@ def compute_position_details(state: dict, prices: Dict[str, float] = None) -> Li
         entry_price = meta.get('entry_price', pos_data.get('avg_cost', 0))
         high_price = meta.get('high_price', entry_price)
         entry_day_index = meta.get('entry_day_index', 0)
-        entry_date = meta.get('entry_date', '')
+        entry_date = _snap_weekend_to_monday(meta.get('entry_date', ''))
         shares = pos_data.get('shares', 0)
         current_price = prices.get(symbol, entry_price)
 
@@ -1612,7 +1626,7 @@ def compute_portfolio_metrics(state: dict, prices: Dict[str, float] = None) -> d
     today_et = datetime.now(ZoneInfo('America/New_York')).date()
     for sym, pos in positions.items():
         meta = position_meta.get(sym, {})
-        entry_date = meta.get('entry_date', '')
+        entry_date = _snap_weekend_to_monday(meta.get('entry_date', ''))
         entry_price = meta.get('entry_price', pos.get('avg_cost', 0))
         # Use entry_price on entry day to avoid phantom PnL from after-hours prices
         if entry_date:

--- a/omnicapital_live.py
+++ b/omnicapital_live.py
@@ -3711,7 +3711,13 @@ class COMPASSLive:
             try:
                 if not isinstance(ed, str) or not ed:
                     raise ValueError
-                date.fromisoformat(ed)
+                parsed_ed = date.fromisoformat(ed)
+                # Snap weekend dates to next Monday
+                if parsed_ed.weekday() >= 5:
+                    days_ahead = 7 - parsed_ed.weekday()  # Mon=0..Sun=6
+                    corrected = parsed_ed + timedelta(days=days_ahead)
+                    logger.warning(f"position_meta[{symbol}]: entry_date={ed} is a weekend, snapping to {corrected.isoformat()}")
+                    entry['entry_date'] = corrected.isoformat()
             except (TypeError, ValueError):
                 logger.warning(f"position_meta[{symbol}]: invalid entry_date={ed!r}, resetting to {today_str}")
                 entry['entry_date'] = today_str

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -216,8 +216,13 @@ function colorCls(v) {
 
 function timeAgo(isoStr) {
     if (!isoStr || isNaN(new Date(isoStr).getTime())) return '\u2014';
-    const d = new Date(isoStr);
+    // Server timestamps are UTC but lack 'Z' suffix — append it to avoid
+    // JS interpreting them as local time (causes negative diff in non-UTC zones)
+    var s = isoStr;
+    if (!s.endsWith('Z') && !/[+-]\d{2}:?\d{2}$/.test(s)) s += 'Z';
+    const d = new Date(s);
     const diff = (Date.now() - d.getTime()) / 1000;
+    if (diff < 0) return 'just now';
     if (diff < 60) return Math.floor(diff) + 's ago';
     if (diff < 3600) return Math.floor(diff/60) + 'm ago';
     if (diff < 86400) return Math.floor(diff/3600) + 'h ago';
@@ -343,7 +348,9 @@ function updateStatusBar(p) {
     const ago = timeAgo(p.timestamp);
     document.getElementById('last-update').textContent = ago;
 
-    const ts = p.timestamp ? new Date(p.timestamp).toLocaleString() : '--';
+    var rawTs = p.timestamp || '';
+    if (rawTs && !rawTs.endsWith('Z') && !/[+-]\d{2}:?\d{2}$/.test(rawTs)) rawTs += 'Z';
+    const ts = rawTs ? new Date(rawTs).toLocaleString() : '--';
     document.getElementById('upd-tooltip').innerHTML =
         t('tooltip-last-update') + ': ' + ts + '<br>' + t('tooltip-next-in') + ': ' + countdownSec + 's';
 }


### PR DESCRIPTION
## Summary
- **Root cause**: Server timestamps lack `Z` suffix → JS `Date()` parses as local time → negative update age (`-13599s ago`) in non-UTC timezones (Peru UTC-5)
- **Fix**: Normalize bare ISO timestamps to UTC in `timeAgo()` + guard for negative diff → shows "just now" instead of negative seconds
- **Defensive**: Added `_snap_weekend_to_monday()` helper in cloud API + state validation to auto-correct any weekend entry_dates on load

## Test plan
- [x] Syntax check: `compass_dashboard_cloud.py`, `omnicapital_live.py` pass
- [x] JSON validation: state file valid
- [x] Tests: 263 passed, 1 pre-existing time-dependent failure (unrelated)
- [ ] Visual verification: after deploy, confirm `UPD` header shows positive age (e.g. "2s ago") instead of "-13599s ago"

🤖 Generated with [Claude Code](https://claude.com/claude-code)